### PR TITLE
Add license and repository details to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
 	"name": "@andrewbranch/untar.js",
 	"version": "1.0.3",
+	"license": "MIT",
 	"description": "untar salvaged from bitjs",
 	"main": "lib/untar.js",
 	"types": "lib/untar.d.ts",
 	"scripts": {
 		"prepublishOnly": "tsc"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/andrewbranch/untar.js.git"
 	},
 	"exports": {
 		".": {


### PR DESCRIPTION
Added the [license field](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license) to the project manifest based on the [project's `LICENSE` file](https://github.com/andrewbranch/untar.js/blob/main/LICENSE).

Also added the repository info since it took me some time to get here from [the npm package](https://www.npmjs.com/package/@andrewbranch/untar.js).